### PR TITLE
feat: Update team ownership to reflect cloud-core team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
 * @idealo/kagahd
-* @idealo/persistence
+* @idealo/cloud-core

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -5,9 +5,9 @@ metadata:
   description: This java web application collects and stores slow operations from one or more mongoDB system(s) in order to visualize and analyze them.
   annotations:
     github.com/project-slug: idealo/mongodb-slow-operations-profiler
-    github.com/team-slug: idealo/persistence
+    github.com/team-slug: idealo/cloud-core
 spec:
   type: service
   lifecycle: production
-  owner: group:persistence
+  owner: group:cloud-core
   system: database-management-toolset


### PR DESCRIPTION
## Summary
This pull request updates file(s) to reflect the team ownership transition from persistence to cloud-core team.

## Changes Made
- .github/CODEOWNERS (1 replacements)
- catalog-info.yaml (2 replacements)

**Total replacements made: 3**

## Team Permissions
- cloud-core team has been granted admin permissions to this repository
- persistence team will be removed after PR approval
- All existing formatting and other team references have been preserved

## Context
This change is part of the team restructuring initiative where cloud-core team is taking ownership of repositories previously managed by persistence team.

The cloud-core team now has admin access to this repository and will be responsible for code ownership and reviews going forward.

## Backstage Integration
This PR includes updates to catalog-info.yaml files to ensure Backstage metadata reflects the new team ownership structure.