### PR TITLE
Fix XSS vulnerability in slowop.jsp

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ The fields at root level define global or default properties:
 
 ## Version history
 * v3.3.1
-  + security: fix reflected XSS vulnerabilities ([Wiz SAST findings](/../../issues/49)) by escaping all request parameters in JSP expressions (`applicationStatus.jsp`, `gui.jsp`)
+  + security: fix reflected XSS vulnerabilities ([Wiz SAST findings](/../../issues/49)) by escaping all request parameters in JSP expressions (`applicationStatus.jsp`, `gui.jsp`, `slowop.jsp`)
   + improvement: pin `alpine/git` Docker image to version `2.47.2` to ensure reproducible builds
   + improvement: add `HEALTHCHECK` instruction to both Dockerfiles
   + bugfix: fix build failure caused by `jackson-annotations:2.21.1` not existing in Maven Central; pinned to `2.21` (the latest available 2.x release for this artifact)

--- a/src/main/webapp/slowop.jsp
+++ b/src/main/webapp/slowop.jsp
@@ -1,6 +1,7 @@
 <%@ page import="org.bson.Document" %>
 <%@ page import="org.bson.json.JsonWriterSettings" %>
 <%@ page import="java.util.List" %>
+<%@ page import="de.idealo.mongodb.slowops.util.Util" %>
 <!DOCTYPE html>
 <html>
 <%@ page language="java" contentType="text/html; charset=ISO-8859-1" pageEncoding="ISO-8859-1" %>
@@ -41,7 +42,7 @@
 			<li>Sorted fields</li>
 			<li>Projected fields</li>
 		</ul>
-		You may <a href="<%=request.getContextPath()%>/slowop?fp=<%=request.getParameter("fp")%>&del=1">delete this</a> example document e.g. if indexes have changed and you want to reflect them in this slow operations example document.<br>
+		You may <a href="<%=request.getContextPath()%>/slowop?fp=<%=Util.escapeHtml(request.getParameter("fp"))%>&del=1">delete this</a> example document e.g. if indexes have changed and you want to reflect them in this slow operations example document.<br>
 		A new example document will be re-created as soon as such an operation is collected again.
 	</span>
 	<pre><%JsonWriterSettings.Builder settingsBuilder = JsonWriterSettings.builder().indent(true);


### PR DESCRIPTION
## Summary
- Escape `request.getParameter("fp")` in `slowop.jsp` with `Util.escapeHtml()` to prevent reflected XSS (GitHub Code Scanning alert #31)
- Update README version history to include `slowop.jsp` in list of fixed files

## Test plan
- [x] Local Docker test: slowop.jsp renders correctly with valid fingerprint parameter
- [x] XSS payload in `fp` parameter is escaped, not rendered as HTML

Closes code scanning alert #31.

🤖 Generated with [Claude Code](https://claude.com/claude-code)