### PR TITLE
Remove HEALTHCHECK and curl from Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,5 @@ FROM tomcat:9-jdk17-openjdk-slim
 COPY --from=builder /usr/src/app/target/mongodb-slow-operations-profiler.war /tmp
 WORKDIR /usr/local/tomcat/webapps/mongodb-slow-operations-profiler/
 RUN jar -xfv /tmp/mongodb-slow-operations-profiler.war
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 RUN chown -R nobody:nogroup /usr/local/tomcat/webapps/
-HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-  CMD curl -f http://localhost:8080/mongodb-slow-operations-profiler/gui || exit 1
 USER nobody:nogroup

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -8,8 +8,5 @@ FROM tomcat:9-jdk17-openjdk-slim
 COPY --from=builder /usr/src/app/target/mongodb-slow-operations-profiler.war /tmp
 WORKDIR /usr/local/tomcat/webapps/mongodb-slow-operations-profiler/
 RUN jar -xfv /tmp/mongodb-slow-operations-profiler.war
-RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 RUN chown -R nobody:nogroup /usr/local/tomcat/webapps/
-HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-  CMD curl -f http://localhost:8080/mongodb-slow-operations-profiler/gui || exit 1
 USER nobody:nogroup

--- a/README.md
+++ b/README.md
@@ -319,7 +319,6 @@ The fields at root level define global or default properties:
 * v3.3.1
   + security: fix reflected XSS vulnerabilities ([Wiz SAST findings](/../../issues/49)) by escaping all request parameters in JSP expressions (`applicationStatus.jsp`, `gui.jsp`, `slowop.jsp`)
   + improvement: pin `alpine/git` Docker image to version `2.47.2` to ensure reproducible builds
-  + improvement: add `HEALTHCHECK` instruction to both Dockerfiles
   + bugfix: fix build failure caused by `jackson-annotations:2.21.1` not existing in Maven Central; pinned to `2.21` (the latest available 2.x release for this artifact)
   + bugfix: show legend for operations with 0ms duration on the analysis page; previously these were hidden because the legend filter incorrectly excluded data points with y-value 0
 * v3.3.0


### PR DESCRIPTION
## Summary
- Remove `HEALTHCHECK` instruction and `curl` installation from both Dockerfiles
- Update README version history to reflect the removal

The HEALTHCHECK required installing curl without a pinned version, causing 2 Medium-severity Wiz IaC findings ("Apt Get Install Pin Version Not Defined"). Since HEALTHCHECK is optional and provides no security benefit for this application, removing it eliminates the Medium findings at the cost of Low-severity "Healthcheck Instruction Missing" findings - a net improvement in severity.

## Test plan
- [x] Docker build still succeeds without HEALTHCHECK
- [ ] Verify Wiz rescan no longer reports "Apt Get Install Pin Version Not Defined"

🤖 Generated with [Claude Code](https://claude.com/claude-code)